### PR TITLE
Fix export of browser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,15 @@
   "description": "Blind signatures over secp256k1, compatible with https://github.com/arnaucube/go-blindsecp256k1",
   "main": "dist/index",
   "types": "dist/index",
+  "exports": {
+    ".": {
+      "browser": {
+        "default": "./dist/blindsecp256k1-browser.js"
+      },
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "prepublishOnly": "npm run build",
     "clean": "rimraf dist",


### PR DESCRIPTION
This fix ensures browser based apps will properly import the already existent `blindsecp256k1-browser.js` file, instead of trying to import node packages (resulting in issues with packages, specially with `crypto`).