### PR TITLE
exclude browser version from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-blindsecp256k1-browser.js
 dist


### PR DESCRIPTION
Hopefully this will be the last PR regarding this... sorry for that.

So the previous versions weren't actually exporting the browser version because it was specifically ignored in the .gitignore file. 